### PR TITLE
Mantém k6 instalado em sessões distintas

### DIFF
--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -1,0 +1,7 @@
+FROM gitpod/workspace-full
+
+USER gitpod
+
+RUN brew tap heroku/brew && brew install \
+    heroku \
+    k6

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,11 +1,9 @@
+image:
+  file: .gitpod.Dockerfile
+
 # List the start up tasks. Learn more https://www.gitpod.io/docs/config-start-tasks/
 tasks:
   - init: |
-      mkdir ~gitpod/bin
-      curl -L https://github.com/grafana/k6/releases/download/v0.34.1/k6-v0.34.1-linux-amd64.tar.gz -o /tmp/k6-v0.34.1-linux-amd64.tar.gz
-      tar xzvf /tmp/k6-v0.34.1-linux-amd64.tar.gz --strip-components=1 -C ~gitpod/bin
-      echo 'export PATH=/home/gitpod/bin:$PATH' >> ~/.bashrc
-      npm install -g heroku
       pipenv install --system
       ./manage.py migrate
     command: ./manage.py runserver 0.0.0.0:8000


### PR DESCRIPTION
O k6 era instalado baixando o executável na home do workspace. A home de um workspace não persiste através das sessões, portanto é necessário disponibiliá-lo de outra forma.

Esta alteração inclui o uso de uma imagem customizada, baseada na oficial da gitpod, que inclui o k6 via brew (linuxbrew). A instalação do heroku também foi migrada para o brew.